### PR TITLE
Improve responsive layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-fit-cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>Sherluuk</title>
   </head>
   <body>

--- a/src/App.css
+++ b/src/App.css
@@ -15,7 +15,12 @@ html, body, #root {
   color: var(--text-main);
 }
 
-.app-root { display:flex; flex-direction:column; min-height:100vh; }
+.app-root {
+  display:flex;
+  flex-direction:column;
+  min-height:100vh;
+  min-height:100dvh;
+}
 .app-shell {
   width:100%; max-width:1200px;
   margin:0 auto; padding:0 24px 48px;
@@ -118,6 +123,7 @@ html, body, #root {
   display: flex;
   flex-direction: column;
   height: 100vh;
+  height: 100dvh;
   padding: 0 8px;
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -186,7 +186,6 @@ export default function App() {
             />
             <div className="content-area">  
               <Grid
-                puzzle={puzzle}
                 cellCandidates={cellCandidates}
                 openCell={openCell}
                 activeCell={activeCell}

--- a/src/Grid.css
+++ b/src/Grid.css
@@ -123,11 +123,11 @@
   :root {
     /* 
       - (100vw – 16px) / 5 ensures 5 columns fit horizontally with 8px side padding 
-      - (100vh – var(--header‑h) – var(--clues‑h) – var(--menu‑h)) / 5 ensures 5 rows fit vertically 
+      - (100dvh – var(--header‑h) – var(--clues‑h) – var(--menu‑h)) / 5 ensures 5 rows fit vertically
     */
     --cell-size: min(
       calc((100vw - 16px) / 5),
-      calc((100vh - var(--header-h) - var(--clues-h) - var(--menu-h)) / 5)
+      calc((100dvh - var(--header-h) - var(--clues-h) - var(--menu-h)) / 5)
     );
   }
   .grid-board {

--- a/src/Grid.jsx
+++ b/src/Grid.jsx
@@ -128,7 +128,7 @@ function ExpandedPanel({ row, col, candidates, onToggle, anchorRect, showWarn })
 }
 
 export default function Grid({
-  puzzle, cellCandidates, openCell, activeCell, anchorRect, closeCell,
+  cellCandidates, openCell, activeCell, anchorRect, closeCell,
   toggleCandidate, showWarn
 }) {
   return (


### PR DESCRIPTION
## Summary
- fix viewport meta so the page scales properly on iPhone
- ensure full height layout using `100dvh`
- compute grid cell size using dynamic viewport height
- drop unused `puzzle` prop from `Grid`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68859249e0dc8329a39c400e46654843