### PR TITLE
Adjust layout and buttons

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -135,3 +135,11 @@ html, body, #root {
   align-items: center;
   justify-content: center;
 }
+
+/* container for the undo button below the grid */
+.undo-wrapper {
+  width: 100%;
+  margin-top: 12px;
+  display: flex;
+  justify-content: flex-end;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import './Clues.css';
 import './Menus.css';
 import './Footer.css';
 import puzzleData from './assets/puzzles/puzzle_schema_example.json';
+import { FaUndo } from 'react-icons/fa';
 import Header from './Header.jsx';
 import Grid from './Grid.jsx';
 import Clues from './Clues.jsx';
@@ -181,7 +182,6 @@ export default function App() {
             <Header
               puzzle={puzzle}
               timer={timer}
-              onUndo={handleUndo}
               onSettings={handleSettings}
             />
             <div className="content-area">  
@@ -194,6 +194,15 @@ export default function App() {
                 toggleCandidate={toggleCandidate}
                 showWarn={showWarn}
               />
+              <div className="undo-wrapper">
+                <button
+                  className="pill-icon"
+                  aria-label="Undo"
+                  onClick={handleUndo}
+                >
+                  <FaUndo size={20} />
+                </button>
+              </div>
               <Clues tab={tab} setTab={setTab} clues={puzzle.clues} />
             </div>
           </div>

--- a/src/Clues.css
+++ b/src/Clues.css
@@ -15,14 +15,7 @@
   font-weight: 500;
   margin-right: 8px;
 }
-.clues-label {
-  font-size: 22px;
-  font-weight: 650;
-  color: #4b4b4b;
-  margin-right: 8px;
-  margin-left: 16px;
-  margin-top: 12px;
-}
+
 
 .tab-pills {
   display: flex;

--- a/src/Clues.jsx
+++ b/src/Clues.jsx
@@ -155,7 +155,6 @@ export default function Clues({ tab, setTab, clues }) {
   return (
     <>
       <div className="puzzle-toolbar">
-        <span className="puzzle-label clues-label">Clues:</span>
         <div className="tab-pills">
           <button
             className={`pill ${tab === 'horizontal' ? 'active' : ''}`}

--- a/src/Footer.css
+++ b/src/Footer.css
@@ -1,5 +1,5 @@
 .footer {
-  margin-top: 40px;
+  margin-top: 60px;
   font-size: 12px;
   color: #555;
   opacity: 0.6;

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { FaUndo, FaCog } from "react-icons/fa";
+import { FaCog } from "react-icons/fa";
 import "./Header.css";
 
 // Helper for MM:SS format
@@ -10,25 +10,16 @@ function formatTimer(ms) {
   return `${m}:${s}`;
 }
 
-export default function Header({ puzzle, timer, onUndo, onSettings }) {
+export default function Header({ puzzle, timer, onSettings }) {
   return (
     <div className="puzzle-toolbar">
-      <div className="toolbar-buttons">
-        <button
-          className="pill-icon"
-          aria-label="Undo"
-          onClick={onUndo}
-        >
-          <FaUndo size={20} />
-        </button>
-        <button
-          className="pill-icon"
-          aria-label="Settings"
-          onClick={onSettings}
-        >
-          <FaCog size={20} />
-        </button>
-      </div>
+      <button
+        className="pill-icon"
+        aria-label="Settings"
+        onClick={onSettings}
+      >
+        <FaCog size={20} />
+      </button>
       <div className="meta-pills">
         <span className="pill-static">{puzzle.date}</span>
         <span className="pill-static">{formatTimer(timer)}</span>


### PR DESCRIPTION
## Summary
- position settings button in header opposite the date and timer
- move undo button below the grid
- drop the clues header text
- space out the footer from the clues section

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688594a1c83c8329baeab69cf052c2a9