### PR TITLE
Update clues layout and remove settings UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -140,7 +140,6 @@ export default function App() {
     setUndoStack(us => us.slice(0, -1));
   };
 
-  const handleSettings = () => alert('Settings menu coming soon!');
 
   // ─── cell popup ───────────────────────────────────────────────
   const openCell = (r, c, btn) => {
@@ -182,7 +181,6 @@ export default function App() {
             <Header
               puzzle={puzzle}
               timer={timer}
-              onSettings={handleSettings}
             />
             <div className="content-area">  
               <Grid

--- a/src/Clues.css
+++ b/src/Clues.css
@@ -51,9 +51,9 @@
 .clue-strip {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 16px 32px; /* row, col gap */
+  gap: 11px 22px; /* row, col gap */
   justify-content: center;
-  margin-top: 32px;
+  margin-top: 22px;
   max-width: calc(5 * 108px + 4 * 12px);
   margin-left: auto;
   margin-right: auto;
@@ -61,9 +61,9 @@
 .clue-strip.horizontal {
   display: grid;
   grid-template-columns: repeat(3, max-content);
-  gap: 16px 32px;
+  gap: 11px 22px;
   justify-content: center;
-  margin-top: 32px;
+  margin-top: 22px;
   max-width: calc(5 * 108px + 4 * 12px);
   margin-left: auto;
   margin-right: auto;
@@ -71,10 +71,10 @@
 .clue-strip.vertical {
   display: flex;
   flex-direction: row;
-  gap: 24px;
+  gap: 17px;
   justify-content: center;
   flex-wrap: nowrap;
-  margin-top: 32px;
+  margin-top: 22px;
   margin-left: auto;
   margin-right: auto;
   width: 100%;
@@ -83,8 +83,8 @@
 }
 .clue-card {
   background: var(--panel);
-  padding: 8px 16px;
-  border-radius: 12px;
+  padding: 6px 12px;
+  border-radius: 8px;
   box-shadow: 0 1px 2px rgba(0,0,0,0.1);
   display: flex;
   align-items: center;
@@ -95,20 +95,20 @@
 }
 .clue-line, .clue-line-vertical {
   display: flex;
-  gap: 8px;
+  gap: 6px;
 }
 .clue-line-vertical { flex-direction: column; align-items: center; }
-.clue-icon { width:36px; height:36px; }
+.clue-icon { width:25px; height:25px; }
 
 .clue-strip.horizontal {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 6px;
-  margin-top: 12px;
+  gap: 4px;
+  margin-top: 8px;
 }
 .clue-card {
   flex: 0 1 auto;
-  padding: 4px 8px;
-  font-size: 13px;
+  padding: 3px 6px;
+  font-size: 10px;
 }

--- a/src/Clues.jsx
+++ b/src/Clues.jsx
@@ -154,6 +154,13 @@ export default function Clues({ tab, setTab, clues }) {
 
   return (
     <>
+      <div className={`clue-strip ${tab}`}>
+        {activeClues.slice(0,9).map((clue,i) => (
+          <div key={i} className="clue-card">
+            <ClueVisual type_id={clue.type_id} items={clue.items}/>
+          </div>
+        ))}
+      </div>
       <div className="puzzle-toolbar">
         <div className="tab-pills">
           <button
@@ -165,13 +172,6 @@ export default function Clues({ tab, setTab, clues }) {
             onClick={() => setTab('vertical')}
           >Column</button>
         </div>
-      </div>
-      <div className={`clue-strip ${tab}`}>
-        {activeClues.slice(0,9).map((clue,i) => (
-          <div key={i} className="clue-card">
-            <ClueVisual type_id={clue.type_id} items={clue.items}/>
-          </div>
-        ))}
       </div>
     </>
   );

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { FaCog } from "react-icons/fa";
 import "./Header.css";
 
 // Helper for MM:SS format
@@ -10,16 +9,9 @@ function formatTimer(ms) {
   return `${m}:${s}`;
 }
 
-export default function Header({ puzzle, timer, onSettings }) {
+export default function Header({ puzzle, timer }) {
   return (
     <div className="puzzle-toolbar">
-      <button
-        className="pill-icon"
-        aria-label="Settings"
-        onClick={onSettings}
-      >
-        <FaCog size={20} />
-      </button>
       <div className="meta-pills">
         <span className="pill-static">{puzzle.date}</span>
         <span className="pill-static">{formatTimer(timer)}</span>


### PR DESCRIPTION
## Summary
- drop the settings button from the header
- move Row/Column tabs under the clues
- shrink clue tiles by about 30%

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688596f2a134832998787d9ee0f97b1e