### PR TITLE
Improve puzzle layout spacing

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -50,11 +50,6 @@ html, body, #root {
     justify-content: flex-start;
     gap: 12px;
   }
-  .meta-pills {
-    margin-left: 0;
-    justify-content: flex-end;
-    gap: 6px;
-  }
 
   /* Clues: allow wrap */
   .clue-strip.horizontal,
@@ -122,8 +117,8 @@ html, body, #root {
 .puzzle-container {
   display: flex;
   flex-direction: column;
-  height: 100vh;
-  height: 100dvh;
+  min-height: 100vh;
+  min-height: 100dvh;
   padding: 0 8px;
 }
 
@@ -133,7 +128,7 @@ html, body, #root {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start; /* remove large vertical gap */
 }
 
 /* container for the undo button below the grid */

--- a/src/Footer.css
+++ b/src/Footer.css
@@ -1,5 +1,5 @@
 .footer {
-  margin-top: 60px;
+  margin-top: 24px; /* tighten space above footer */
   font-size: 12px;
   color: #555;
   opacity: 0.6;

--- a/src/Header.css
+++ b/src/Header.css
@@ -6,10 +6,11 @@
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  margin: 16px 0 20px; /* 16px top, 20px bottom */
+  margin: 8px 0 12px; /* reduced spacing */
   padding: 0;
   background: none;
   border: none;
+  gap: 8px; /* space between pills on small widths */
 }
 
 /* ── ICON BUTTON GROUP ───────────────────────────────────────── */
@@ -61,13 +62,6 @@
 }
 
 /* ── STATIC META PILLS (DATE & TIMER) ────────────────────────── */
-.meta-pills {
-  display: flex;
-  gap: 8px;
-  margin: 0;
-  margin-left: auto; /* pushes pills to the right */
-  align-items: center;
-}
 
 .pill-static {
   display: inline-block;

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -12,10 +12,8 @@ function formatTimer(ms) {
 export default function Header({ puzzle, timer }) {
   return (
     <div className="puzzle-toolbar">
-      <div className="meta-pills">
-        <span className="pill-static">{puzzle.date}</span>
-        <span className="pill-static">{formatTimer(timer)}</span>
-      </div>
+      <span className="pill-static pill-date">{puzzle.date}</span>
+      <span className="pill-static pill-timer">{formatTimer(timer)}</span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- align date left and timer right in header
- reduce space above grid and footer
- prevent vertical centering that created large gaps

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688598db09488329a05ae6eca5adf63c